### PR TITLE
no longer links to 404

### DIFF
--- a/our-work/index.md
+++ b/our-work/index.md
@@ -40,7 +40,7 @@ Internally we’ve been focused on our [Open@RIT Fellows][] work supporting over
 [UNICEF Ventures]: https://www.unicef.org/innovation/stories
 [Fedora Badges]: https://badges.fedoraproject.org/about
 [Open APS]: https://openaps.org/
-[Open@RIT Fellows]: {{ "/faculty/fellows" | relative_url }}
+[Open@RIT Fellows]: {{ "/our-work/fellows-projects" | relative_url }}
 
 ## Projects
 


### PR DESCRIPTION
#7 
Changes link of 'Open@RIT fellows' on Our Work page from /faculty/fellows to /our-work/fellows-projects/