### PR TITLE
update advisory link + job titles

### DIFF
--- a/_data/members.yml
+++ b/_data/members.yml
@@ -39,8 +39,8 @@ advisory_board:
   degree: BS New Media Publishing, RIT ‘96
   headshot: https://www.rit.edu/sites/rit.edu/files/images/paragraph/image-card/matthew-bernius.jpg
 - name: Deb Nicholson
-  role: Interim Director
-  org: The Open Source Initiative
+  role: Executive Director
+  org: Python Software Foundation
   headshot: https://www.rit.edu/sites/rit.edu/files/images/paragraph/image-card/deb-nicholson.jpg
 - name: Silona Bonewald
   role: Executive Director
@@ -49,50 +49,52 @@ advisory_board:
 - name: Mel Chua
   role: ABD, Purdue, School of Engineering Education
   headshot: https://www.rit.edu/sites/rit.edu/files/images/paragraph/image-card/mel-chua.jpg
-- name: Ihudiya Finda Ogbonnaya-Ogburu
-  role: HCI Researcher (PhD candidate)
+- name: Dr. Ihudiya Finda Williams
+  role: HCI Educator and Researcher
   org: University of Michigan School of Information
-  degree: BS, Information Technology, RIT  2010
+  degree: BS, Information Technology, RIT  2010 & Ph.D., Information Science, UMSI 2023
   headshot: https://www.rit.edu/sites/rit.edu/files/images/paragraph/image-card/ihudiya-finda.jpg
 - name: Remy DeCausemaker
-  role: BS & MS, School of Independent Study, RIT '08, '13
+  role: Open Source Lead
+  org: Digital Service at Centers for Medicare & Medicaid Services (CMS)
+  degree: BS & MS, School of Independent Study, RIT '08, '13
   headshot: https://www.rit.edu/sites/rit.edu/files/images/paragraph/image-card/remy-decausemaker.jpg
 - name: Nithya Ruff
-  role: Board Director & Head of Open Source
-  org: Comcast, Inc
+  role: Head of Open Source Program Office
+  org: Amazon
   headshot: https://www.rit.edu/sites/rit.edu/files/images/paragraph/image-card/nithya-ruff.jpg
 - name: Justin W. Flory
-  role: FOSS Technical Advisor
-  org: UNICEF Innovation
+  role: Fedora Community Architect
+  org: Red Hat
   degree: B.S. Networking & Systems Administration, Minor, Free & Open Source Software & Free Culture, RIT 202
   headshot: https://www.rit.edu/sites/rit.edu/files/images/paragraph/image-card/justin-flory.jpg
 - name: Justin Sherrill
-  role: Developer
-  org: DragonFly BSD
+  role: IT Director
+  org: Garden Trends, Inc.
   degree: Information Technology Masters, 2002
   headshot: https://www.rit.edu/sites/rit.edu/files/images/paragraph/image-card/justin-sherrill.jpg
 - name: Wilfried Hounyo
   role: Software Engineer
-  org: Zendesk, INc
-  degree: BS in Computer Science
+  org: Zendesk, Inc.
+  degree: BS in Computer Science, 2019
   headshot: https://www.rit.edu/sites/rit.edu/files/images/paragraph/image-card/wilfried-hounyo.jpg
 - name: Kyle Suero
-  role: Application Security Engineer III
-  org: Reddit
+  role: Founder
+  org: Hackathon Mentors
   degree: BS, Computing Security, RIT, 2019
   headshot: https://www.rit.edu/sites/rit.edu/files/images/paragraph/image-card/kyle-suero.jpg
 - name: Jenn Kotler
-  role: UX Designer
+  role: Senior UX Designer
   org: Space Telescope Science Institute
-  degree: BS Medical Illustration, RIT 2014
+  degree: BS, Medical Illustration, RIT 2014
   headshot: https://www.rit.edu/sites/rit.edu/files/images/paragraph/image-card/kotler.jpg
 - name: Tom Callaway
   role: Principal Open Source
   org: Evangelist, Amazon Web Services
   headshot: https://www.rit.edu/sites/rit.edu/files/images/paragraph/image-card/tom.jpg
 - name: Ruth Suehle
-  role: Director, Software Engineering
-  org: Global, RedHat
+  role: Director, Open Source
+  org: SAS
   headshot: https://www.rit.edu/sites/rit.edu/files/images/paragraph/image-card/ruth.jpeg
 - name: Chris Aniszczyk
   role: Chief Technology Officer, Cloud Native Computing Foundation Vice President, Developer Relations
@@ -103,6 +105,6 @@ advisory_board:
   org: Google Open Source Programs Office
   headshot: https://www.rit.edu/sites/rit.edu/files/images/paragraph/image-card/erin-mckean-200_0.jpg
 - name: April Kyle Nassi
-  role: Google for Games Open Source Strategist
+  role: Senior Program Manager 
   org: Google
   headshot: https://www.rit.edu/sites/rit.edu/files/images/paragraph/image-card/apriladvisoryboard_0.jpg

--- a/best-practices/index.md
+++ b/best-practices/index.md
@@ -21,11 +21,13 @@ subnav:
 
 ## Best Practices Around Open Work
 
-The following best practices have been derived from a combination of both industry and academic policies and reviewed by our [advisory board](https://www.rit.edu/research/open#people). Their intent is to help guide you in a manner that allows your efforts to have the most impact while potentially protecting you and the University from any cultural or legal conflicts around your efforts. Should you have any questions about them feel free to contact Open@RIT Director [Stephen Jacobs](https://www.rit.edu/directory/sxjics-stephen-jacobs) or Assistant Director [Michael Nolan](https://www.rit.edu/directory/mpnopen-michael-nolan).
+The following best practices have been derived from a combination of both industry and academic policies and reviewed by our [advisory board][]. Their intent is to help guide you in a manner that allows your efforts to have the most impact while potentially protecting you and the University from any cultural or legal conflicts around your efforts. Should you have any questions about them feel free to contact Open@RIT Director [Stephen Jacobs](https://www.rit.edu/directory/sxjics-stephen-jacobs) or Assistant Director [Michael Nolan](https://www.rit.edu/directory/mpnopen-michael-nolan).
 
 While these are our recommendations, they are not official university policy nor do they qualify as official legal advice. In all cases, should you have any questions around policy or legal questions, refer to the appropriate offices of the university for official clarification for RIT projects or a personal lawyer for personal projects.
 
 **Any suggestions on how to improve this document, or strengthen it for any given discipline, are encouraged.**
+
+[advisory board]: {{ "/about/people#advisory-board" | relative_url }}
 
 #### Contributing to Existing Open Projects
 


### PR DESCRIPTION
I went through each person's Linkedin account to update their roles on the advisory page. There were some I could not find, so I did not update theirs. I also updated the advisory board link as specified in issue #9